### PR TITLE
removed sudo references in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update -y
 RUN apt-get install -y curl gcc-4.9 g++-4.9 libstdc++-4.9-dev
 
 RUN apt-get install -y python python-dev python-pip git build-essential wget && \
-	curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - && \
-	sudo apt-get -y install nodejs && \
+	curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+	apt-get -y install nodejs && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 #everything needed by extensions


### PR DESCRIPTION
#### Overview
The sudo command is typically not present within the context of a Dockerfile and thus, when referenced, break the docker build.

Dockerfile commands run as root (unless a USER directive has been made previously in the Dockerfile). Thus commands that require root level privilege, such as apt-get, do not need to have `sudo` in front of these commands.

Note that this is different than when these commands run interactively within a Linux shell, **unless you are running as root** within the Linux shell. 

You can see whom are you running as in Linux via the `whoami` command.
You can run interactively as root via the `sudo -i` command. When finished running root-level commands, use `exit` to stop the root-level shell and return to your normal interactive user shell. 


#### Type of change (bug fix, feature, docs, UI, etc.)
bug fix


#### Breaking Changes
None


#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information

See description above.

#### Issue


