### PR TITLE
Recommend devs use `npm run start-instance`

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -20,7 +20,7 @@ Easiest way to get set up, using mocked authentication. In this installation, th
 
 `npm install`
 
-`npm run start`
+`npm run start-instance`
 
 ### In a Docker Container
 


### PR DESCRIPTION
#### Overview

Recommend devs use `npm run start-instance` instead of `npm run start` (`npm start`).

`npm run start` doesn't start a webserver.  `run-instance` does.

Documentation only.