### PR TITLE
Remove extraneous double quote char in docs

### DIFF
--- a/docs/extensions/ClientExtensions.md
+++ b/docs/extensions/ClientExtensions.md
@@ -28,7 +28,7 @@ There are several examples in `/extensions/`. Here is a simple one:
     "type": "Background Script",
     "client": [
       {
-        "file": ""index.js",
+        "file": "index.js",
         "region": null
       }
     ]


### PR DESCRIPTION
Fixes a typo in the [Client extensions documentation](https://github.com/Autodesk/genetic-constructor/blob/master/docs/extensions/ClientExtensions.md), causing funny syntax highlighting;

![screen shot 2016-10-25 at 4 06 26 pm](https://cloud.githubusercontent.com/assets/325176/19671689/08f700aa-9acd-11e6-8136-641fcbd750ec.png)
