### PR TITLE
Removed Dockerfile fsharp install command, modified docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ RUN npm update -g npm && npm install
 
 ADD . /app
 
-#install fsharp (needed by gslEditor extension if it exists)
-RUN if [ -d ./extensions/gslEditor/ ]; then ./extensions/gslEditor/tools/install-fsharp.sh ; fi
-
 #install extensions, continue even if errors
 RUN npm run install-extensions || true
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -45,9 +45,7 @@ If you have the bio-user-platform installed, you can run the server with authent
 
 ## Extensions
 
-Once the server is up and running, you might need to make sure that certain specific server requirements as noted in the extension's README.md are installed. Currently, only the `gslEditor` extension requires manual installation of Mono/F# on the server as it requires `sudo` access to do so. If you need to run GSL code within the `gslEditor` extension, you could view [its README.md](../extensions/gslEditor/README.md) for Mono/F# installation instructions or run following command:
-
-`./extensions/gslEditor/tools/install-fsharp.sh`
+Once the server is up and running, you might need to make sure that specific server requirements as noted in the extension's README.md are installed in case you are running the extension's server (if any) locally.
 
 ## Troubleshooting
 

--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -45,7 +45,7 @@ If you have the bio-user-platform installed, you can run the server with authent
 
 ## Extensions
 
-Once the server is up and running, you might need to make sure that specific server requirements as noted in the extension's README.md are installed in case you are running the extension's server (if any) locally.
+Extensions should not require additional dependencies or installations steps. They may run scripts that hook into npm or git to accomplish any additional steps automatically. If you experience problems with an extension, check its README.
 
 ## Troubleshooting
 


### PR DESCRIPTION
#### Overview

Remove Dockerfile command to run fsharp as GSL server is not a part of the app server. Modified docs

#### Type of change (bug fix, feature, docs, UI, etc.)

Fix

#### Breaking Changes

None

#### Requirements

- [ ] Adds a test (for features + fixes)
- [x] Docs updated (for features + fixes)

#### Other information



#### Issue

