### PR TITLE
update image name after merge into master

### DIFF
--- a/docker-compose-migrate.yml
+++ b/docker-compose-migrate.yml
@@ -1,6 +1,6 @@
 migrate:
-#  image: quay.io/autodesk_bionano/gctordb_webapp${BNR_ENV_TAG}
-  image: geneticconstructor_webapp:latest # local build
+  image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
+#  image: geneticconstructor_webapp:latest # local build
   volumes:
     - /storage/genome-designer/projects:/projects
   environment:

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -2,7 +2,7 @@ webapp:
   extends:
     file: docker-compose.yml
     service: webapp
-  image: quay.io/autodesk_bionano/gctordb_webapp${BNR_ENV_TAG}
+  image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
   volumes:
     - /storage/genome-designer/projects:/projects
   environment:


### PR DESCRIPTION
#### Overview

This change updates the Docker image name references to the usual `gctor_webapp` from the `gctordb-webapp` that was being used before the Storage API changes were merged into `master`.

#### Type of change (bug fix, feature, docs, UI, etc.)

Configuration change to docker-compose files used to for deployment in AWS.