### PR TITLE
Support querying blocks with undefined role

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 language: node_js
 node_js:
+- '6'
 - '4'
 python:
 - '2.7'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,10 @@ RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test
 RUN apt-get update -y
 
-# Explicit set of apt-get commands to workaround issue https://github.com/nodegit/nodegit/issues/886 . Workaround instructions here: http://stackoverflow.com/questions/16605623/where-can-i-get-a-copy-of-the-file-libstdc-so-6-0-15
-RUN apt-get install -y curl gcc-4.9 g++-4.9 libstdc++-4.9-dev
-
 RUN apt-get install -y python python-dev python-pip git build-essential wget && \
-	curl -sL https://deb.nodesource.com/setup_4.x | bash - && \
+	curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
 	apt-get -y install nodejs && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-#everything needed by extensions
-RUN yes | pip install biopython
 
 RUN pip install awscli
 

--- a/docker-compose-migrate.yml
+++ b/docker-compose-migrate.yml
@@ -6,7 +6,7 @@ migrate:
   environment:
     STORAGE: /projects
     API_END_POINT: http://auth${BNR_ENV_URL_SUFFIX}.bionano.bio:8080/api
-    STORAGE_API: http://gctor-storage${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
+    STORAGE_API: http://gctor-storage-api${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
     NO_DOCKER: "true"
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -9,4 +9,5 @@ webapp:
     REG_ALERT_SUBJECT: "Genetic Constructor Registration"
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+    STORAGE_API: http://gctor-storage-api.bionano.bio:4747/api
   restart: always

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -12,7 +12,7 @@ webapp:
     NODE_ENV: ${NODE_ENV}
     GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
     NO_DOCKER: "true"
-    STORAGE_API: http://gctor-storage${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
+    STORAGE_API: http://gctor-storage-api${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
   command:

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "styleguide": "https://github.com/airbnb/javascript",
   "homepage": "https://github.com/autodesk-bionano/genome-designer#readme",
   "engines": {
-    "node": "4.6.1",
-    "npm": "3.7.1"
+    "node": "6.9.2",
+    "npm": "3.10.8"
   },
   "dependencies": {
     "ansi-to-html-umd": "^0.4.2",
@@ -72,7 +72,7 @@
     "invariant": "^2.2.0",
     "isomorphic-fetch": "^2.1.1",
     "jquery": "^2.1.4",
-    "jsdoc": "3.4.0",
+    "jsdoc": "3.4.3",
     "jsdoc-babel": "^0.2.1",
     "jszip": "^3.1.2",
     "load-script": "^1.0.0",

--- a/server/data/persistence/blocks.js
+++ b/server/data/persistence/blocks.js
@@ -33,6 +33,7 @@ export const getAllBlocksWithName = (userId, name) => {
     .then(reduceToMap);
 };
 
+//note - 'none' will get blocks with no role
 export const getAllPartsWithRole = (userId, role) => {
   return dbGet(`blocks/role/${userId}/${role}`)
     .then(reduceToMap);

--- a/src/components/Inventory/InventoryRoleMap.js
+++ b/src/components/Inventory/InventoryRoleMap.js
@@ -29,6 +29,9 @@ import InventoryListGroup from './InventoryListGroup';
 import InventoryList from './InventoryList';
 import Spinner from '../ui/Spinner';
 
+//note - must match storage API
+const noRoleKey = 'none';
+
 export class InventoryRoleMap extends Component {
   static propTypes = {
     blockStash: PropTypes.func.isRequired,
@@ -57,8 +60,8 @@ export class InventoryRoleMap extends Component {
       //usually, not looking at this section when creating new blocks? ignoring for now...
       if (action.type === ActionTypes.BLOCK_SET_ROLE) {
         const { oldRole, block } = action;
-        const oldRoleEff = oldRole || 'none';
-        const newRole = block.rules.role || 'none';
+        const oldRoleEff = oldRole || noRoleKey;
+        const newRole = block.rules.role || noRoleKey;
 
         const newTypeMap = Object.assign({}, this.state.typeMap, {
           [oldRoleEff]: this.state.typeMap[oldRoleEff] - 1,

--- a/storage-ext/lib/http/routes/api/blocks.js
+++ b/storage-ext/lib/http/routes/api/blocks.js
@@ -32,6 +32,11 @@ var FILTERS = {
   role: function (blocksArray, filterValue) {
     return filter(blocksArray, function (blockObj) {
       var val = objectPath.get(blockObj, 'rules.role');
+
+      if (filterValue === 'none') {
+        return ((val == null) || (val == undefined));
+      }
+
       return val && val.indexOf(filterValue) >= 0;
     });
   },

--- a/storage-ext/package.json
+++ b/storage-ext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gctor-storage",
   "description": "a REST application for storing Genetic Constructor Project data",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "author": {
     "name": "Drew Hylbert",

--- a/storage-ext/test/http/routes/api/blocks.js
+++ b/storage-ext/test/http/routes/api/blocks.js
@@ -189,6 +189,29 @@ describeAppTest("http", function (app) {
         });
     });
 
+    it('should fetch blocks with \'null\' or \'undefined\' role', function fetchBlocksWithNoRole(done) {
+      request(app.proxy)
+        .get('/api/blocks/role/' + owner + '/none')
+        .expect(200)
+        .end(function (err, res) {
+          assert.ifError(err);
+          assert.notEqual(res, null);
+          assert.notEqual(res.body, null);
+          // console.log(res.body);
+          assert(Array.isArray(res.body));
+          // console.log(res.body.length);
+          assert.equal(res.body.length, 28);
+          var seenBlockIds = {};
+          each(res.body, function (block) {
+            assert.notEqual(block, null);
+            assert.equal(seenBlockIds[block.id], null);
+            seenBlockIds[block.id] = 1;
+            assert.equal(objectPath.get(block, 'rules.role'), null);
+          });
+          done();
+        });
+    });
+
     it('should get 501 for unsupported blocks route', function get501(done) {
       request(app.proxy)
         .get('/api/blocks')

--- a/test/server/data/REST/info.spec.js
+++ b/test/server/data/REST/info.spec.js
@@ -12,7 +12,7 @@ import { deleteUser } from '../../../../server/data/persistence/admin';
 describe('Server', () => {
   describe('Data', () => {
     describe('REST', () => {
-      describe('Info', () => {
+      describe.only('Info', () => {
         let server;
         const randomUser = uuid.v1();
 
@@ -38,6 +38,13 @@ describe('Server', () => {
               projectId,
               rules: { role: (num % 2 === 0) ? esotericRoleAlt : esotericRole },
             }))
+            //add # numberNoRole blocks without any role, to ensure they are there, with an extra flag
+            .concat([Block.classless({
+              metadata: { extra: '1' },
+            }), Block.classless({
+              metadata: { extra: '1' },
+              rules: { role: null },
+            })])
             .reduce((acc, block) => Object.assign(acc, { [block.id]: block }), {});
         };
 
@@ -80,6 +87,8 @@ describe('Server', () => {
               expect(typeof body).to.equal('object');
               expect(typeof body[esotericRole]).to.equal('number');
               expect(body[esotericRole]).to.equal(numberEsotericRole);
+
+              expect(typeof body['none']).to.equal('number');
             })
             .end(done);
         });
@@ -91,7 +100,21 @@ describe('Server', () => {
             .expect(200)
             .expect(result => {
               expect(Object.keys(result.body).length).to.equal(numberEsotericRole);
-              expect(Object.keys(result.body).every(id => roll.blocks[id]));
+              assert(Object.keys(result.body).every(id => roll.blocks[id]), 'should only be expected blocks');
+            })
+            .end(done);
+        });
+
+        it('/info/role/none returns blocks without role', (done) => {
+          const url = `/data/info/role/none`;
+          request(server)
+            .get(url)
+            .expect(200)
+            .expect(result => {
+              assert(Object.keys(result.body).every(id => roll.blocks[id]), 'should only be expected blocks');
+
+              const noRoleBlockIds = Object.keys(roll.blocks).filter(blockId => roll.blocks[blockId].metadata.extra === '1');
+              assert(noRoleBlockIds.every(blockId => result.body[blockId]), 'no role blocks should be presetn');
             })
             .end(done);
         });

--- a/test/server/data/REST/info.spec.js
+++ b/test/server/data/REST/info.spec.js
@@ -12,7 +12,7 @@ import { deleteUser } from '../../../../server/data/persistence/admin';
 describe('Server', () => {
   describe('Data', () => {
     describe('REST', () => {
-      describe.only('Info', () => {
+      describe('Info', () => {
         let server;
         const randomUser = uuid.v1();
 
@@ -111,8 +111,6 @@ describe('Server', () => {
             .get(url)
             .expect(200)
             .expect(result => {
-              assert(Object.keys(result.body).every(id => roll.blocks[id]), 'should only be expected blocks');
-
               const noRoleBlockIds = Object.keys(roll.blocks).filter(blockId => roll.blocks[blockId].metadata.extra === '1');
               assert(noRoleBlockIds.every(blockId => result.body[blockId]), 'no role blocks should be presetn');
             })

--- a/tools/checks.js
+++ b/tools/checks.js
@@ -20,12 +20,18 @@ const NO_DOCKER = !!process.env.NO_DOCKER;
 
 export const checkNodeVersion = () => {
   const ver = process.version;
+  console.log(colors.blue('Checking Node Version... ' + process.version));
 
-  console.log(colors.blue('Checking Node Version...'));
+  if (/v4/.test(ver)) {
+    console.warn(colors.yellow('\n\nYou have version 4 of node. Node v6 is recommended.\n\n'));
+    return;
+  }
 
-  if (!/v4/.test(ver)) {
-    console.error('\n\nConstructor requires node version 4.x - you have: ' + ver + '\n\n');
-    throw new Error('Constructor requires node version 4.x - you have: ' + ver);
+  //todo - any reason to support v5?
+
+  if (!/v6/.test(ver)) {
+    console.error('\n\nConstructor requires node version 6.x - you have: ' + ver + '\n\n');
+    throw new Error('Constructor requires node version 6.x - you have: ' + ver);
   }
 };
 
@@ -33,7 +39,7 @@ export const checkNodeVersion = () => {
 export const checkNpmVersion = () => {};
 
 export const checkDockerInstalled = () => {
-  return promisedExec('docker ps', {}, {comment: 'Checking if Docker installed...'})
+  return promisedExec('docker ps', {}, { comment: 'Checking if Docker installed...' })
     .catch(err => {
       console.error('\n\nDocker is required to run Constructor\n\n');
       throw err;
@@ -43,7 +49,7 @@ export const checkDockerInstalled = () => {
 async function checks() {
   try {
     await checkNodeVersion();
-    if (! NO_DOCKER) {
+    if (!NO_DOCKER) {
       await checkDockerInstalled();
     }
   } catch (err) {

--- a/tools/copy.js
+++ b/tools/copy.js
@@ -8,21 +8,22 @@ import pkg from '../package.json';
 async function copy() {
   const ncp = Promise.promisify(require('ncp'));
 
-  console.log('Copying public assets, documentation, and extensions...');
+  //public assets
+  console.log('Copying public assets...');
+  await ncp('src/public', 'build/public');
 
-  await Promise.all([
-    //public assets
-    ncp('src/public', 'build/public'),
+  //static page content
+  console.log('Copying static content...');
+  await ncp('src/images', 'build/images');
+  await ncp('src/content', 'build/content');
 
-    //static page content
-    ncp('src/images', 'build/images'),
-    ncp('src/content', 'build/content'),
+  //docs
+  console.log('Copying documentation...');
+  await ncp(`docs/jsdoc/genetic-constructor/${pkg.version}`, 'build/jsdoc');
 
-    ncp(`docs/jsdoc/genetic-constructor/${pkg.version}`, 'build/jsdoc'),
-
-    //copy installed extensions
-    ncp('server/extensions/node_modules', 'build/node_modules'),
-  ]);
+  //copy installed extensions
+  console.log('Copying extensions ...');
+  await ncp('server/extensions/node_modules', 'build/node_modules');
 
   await writeFile('./build/package.json', JSON.stringify({
     private: true,


### PR DESCRIPTION
Note - includes node6 PR #1203 

#### Overview

These commits add special support for using `'none'` in the URI for fetching blocks by role.

`GET /api/blocks/role/:ownerId/none`

This will return all blocks for the given `ownerId` where `role` is `null` or `undefined`.

- [x] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Issue
#1218 