### PR TITLE
simplify local authentication start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "start-instance": "./node_modules/.bin/babel-node tools/run start-instance",
     "start-docker": "docker build -t genome-designer . && docker run --privileged -v /var/run/docker.sock:/run/docker.sock -i -p 3000:3000 -t genome-designer",
     "start-db": "./node_modules/.bin/babel-node tools/run startDb",
-    "auth": "./bin/local-auth.sh",
     "server-auth": "EMAIL=1 COMMAND='npm run start-instance -- --release' ./bin/server-auth.sh",
     "postinstall": "npm run install-extensions && npm run selenium && npm run jsdoc && ./node_modules/.bin/babel-node tools/run install-dependencies",
     "build": "./node_modules/.bin/babel-node tools/run build",


### PR DESCRIPTION
The move to DB-backed project storage changes the way a user would enable DB-backed authentication for local development. The `npm run auth` target assumes a user would have the entire `bio-user-platform` application running, including DB, and then the would need to override the DB password used by GCTOR storage to save projects.

To make this more simple, I removed the `npm run auth` target; I'm probably the only person that would have a `bio-user-platform` stack running locally. I then updated the `npm run start-auth` procedure to install the authentication module from the directory to which the `bio-user-platform` user platform is cloned locally. I also fixed some log messages to make them more clear.