### PR TITLE
exit main process when server crashes in runServer()

### DIFF
--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -395,7 +395,7 @@ export default class Block extends Instance {
    * @returns {Block}
    */
   setProjectId(projectId) {
-    invariant(idValidator(projectId) || projectId === null, 'project Id is required, or null to mark unassociated');
+    invariant(projectId === null || idValidator(projectId), 'project Id is required, or null to mark unassociated');
     invariant(!this.projectId || (this.projectId && projectId === null), 'if project ID is set, must unset first');
 
     if (this.projectId === projectId) {

--- a/tools/runServer.js
+++ b/tools/runServer.js
@@ -1,5 +1,5 @@
 import cp from 'child_process';
-import colors from 'colors';
+import colors from 'colors/safe';
 //import { serverConfig } from './webpack.config';
 
 // Should match the text string used in `src/server.js/server.listen(...)`
@@ -75,7 +75,10 @@ function runServer(cb) {
       return; //in case not sync...
     }
 
-    console.log(`Server exited with code ${code} and signal ${signal}`);
+    //otherwise something bad happened and we should we restart
+    //restarting can be tricky, so kill to be save. you could probably recursively call runServer() if you wanted..
+    console.log(colors.red(`Server exited with code ${code} and signal ${signal}`));
+    process.exit(1);
   });
 }
 


### PR DESCRIPTION
#### Overview

`npm run start` exits when server dies unexpectedly

#### Type of change (bug fix, feature, docs, UI, etc.)

fix

#### Breaking Changes

none

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

