### PR TITLE
Config fixes for start-auth and support for beta Docker versions

### DIFF
--- a/tools/auth-stack.js
+++ b/tools/auth-stack.js
@@ -17,6 +17,7 @@ import path from 'path';
 import run from './run';
 import setup from './setup';
 import { spawnAsync, promisedExec } from './lib/cp';
+import HOST_URL from '../server/urlConstants';
 
 /** paths **/
 
@@ -69,12 +70,12 @@ const startRunAuth = () => {
     { cwd: pathProjectRoot,
       env: Object.assign({
         BIO_NANO_AUTH: 1,
-        HOST_URL: 'http://localhost:3000',
+        HOST_URL: HOST_URL,
       }, process.env),
     },
     {
       comment: 'Starting Constructor with Authentication...',
-      waitUntil: 'Server listening at http://0.0.0.0:3000/',
+      waitUntil: 'Server listening at ' + HOST_URL + '/',
       forceOutput: true,
       failOnStderr: false,
     }

--- a/tools/checks.js
+++ b/tools/checks.js
@@ -48,7 +48,8 @@ export const checkDockerInstalled = () => {
       const version = findVersions(result, { loose: true });
       console.log('Found version ' + version);
 
-      const [/*match*/, major, minor] = /^(\d+)\.?(\d+)\.?(\*|\d+)$/.exec(version);
+      const [/*match*/, major, minor] = /^(\d+?)\.(\d+?)\.(.+)$/.exec(version);
+      // we ignore the 'Z' version of Docker but keep in mind it may not always be an integer
       if (major < 1 || minor < 12) {
         console.error(colors.red('Docker version > 1.12 is required'));
         throw Error('Docker > 1.12 required');


### PR DESCRIPTION
#### Overview

small changes to local environment automation

#### Type of change (bug fix, feature, docs, UI, etc.)

Docker beta versions would cause errors on startup because of RegEx parsing expecting 3 integers for the version. This is now fixed.

The auth startup uses `HOST_URL` variable from configuration instead of being hard-coded.

#### Breaking Changes

none