### PR TITLE
more lint fixes to loader.io support changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "style-loader": "^0.13.0",
     "url-regex": "^3.0.0",
     "urlsafe-base64": "^1.0.0",
+    "uuid": "^3.0.1",
     "yamljs": "^0.2.4"
   },
   "devDependencies": {

--- a/server/data/router.js
+++ b/server/data/router.js
@@ -202,7 +202,7 @@ router.route('/projects')
 
     return projectPersistence.getUserProjects(user.uuid, false)
       .then(rolls => rolls.map(roll => roll.project))
-      .then(manifests => {
+      .then((manifests) => {
         res.set('Last-Project-ID', mostRecentProject(manifests).id);
         return manifests;
       })

--- a/server/data/routerLoaderSupport.js
+++ b/server/data/routerLoaderSupport.js
@@ -15,7 +15,7 @@
  */
 import express from 'express';
 
-import * as uuid from 'uuid';
+import uuid from 'uuid';
 import { projectPermissionMiddleware } from './permissions';
 
 import {
@@ -36,17 +36,17 @@ router.route('/savecomponent/:projectId?')
 
     projectPersistence.projectGet(projectId)
       .then((rollup) => {
-        if (! rollup) {
+        if (!rollup) {
           return res.status(404).send(errorDoesNotExist);
         }
 
         const constructId = rollup.project.components[0];
         const construct = rollup.blocks[constructId];
-        const newBlockID = 'block-' + uuid.v4();
+        const newBlockID = `block-${uuid.v4()}`;
         const newBlock = new Block(Object.assign({}, construct, {
           id: newBlockID,
         }), false);
-        newBlock.metadata.name = 'loaderCreated-' + Date.now();
+        newBlock.metadata.name = `loaderCreated-${Date.now()}`;
         const blocksToMerge = {};
         blocksToMerge[newBlock.id] = newBlock;
         return projectPersistence.blocksMerge(projectId, user.uuid, blocksToMerge)


### PR DESCRIPTION
#### Overview

Looks like @maxbates changes a few lint rules after the first loader PR was passing lint checks and got merged into `master`. These changes fix the new lint errors. 

#### Issue

#1266 
