### PR TITLE
Context menus redux

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,15 @@
     "jsx-a11y/img-has-alt": 1,
 
     // order of operations are fine, if you don't know them time for a new career
-    "no-mixed-operators": 0
+    "no-mixed-operators": ["error,
+        {
+            "groups": [
+                ["&", "|", "^", "~", "<<", ">>", ">>>"],
+                ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+                ["&&", "||"],
+                ["in", "instanceof"]
+            ],
+            "allowSamePrecedence": true
+        }
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,16 @@
     "jsx-a11y/img-has-alt": 1,
 
     // order of operations are fine, if you don't know them time for a new career
-    "no-mixed-operators": 0
+    "no-mixed-operators": [
+       "error",
+       { "groups": [
+                 ["&", "|", "^", "~", "<<", ">>", ">>>"],
+                 ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+                 ["&&", "||"],
+                 ["in", "instanceof"]
+             ],
+           "allowSamePrecedence": true
+       }
+    ]
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,9 @@
     "jsx-a11y/no-static-element-interactions": 0,
 
     //meh
-    "jsx-a11y/img-has-alt": 1
+    "jsx-a11y/img-has-alt": 1,
+
+    // order of operations are fine, if you don't know them time for a new career
+    "no-mixed-operators": 0
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -72,15 +72,6 @@
     "jsx-a11y/img-has-alt": 1,
 
     // order of operations are fine, if you don't know them time for a new career
-    "no-mixed-operators": ["error,
-        {
-            "groups": [
-                ["&", "|", "^", "~", "<<", ">>", ">>>"],
-                ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
-                ["&&", "||"],
-                ["in", "instanceof"]
-            ],
-            "allowSamePrecedence": true
-        }
+    "no-mixed-operators": 0
   }
 }

--- a/src/components/Menu/MenuOverlay.js
+++ b/src/components/Menu/MenuOverlay.js
@@ -75,6 +75,7 @@ class MenuOverlay extends Component {
   stopKillTimer() {
     window.clearTimeout(this.killTimer);
   }
+
   startKillTimer() {
     this.stopKillTimer();
     this.killTimer = window.setTimeout(() => {
@@ -115,16 +116,27 @@ class MenuOverlay extends Component {
     if (!this.props.menuItems) {
       return null;
     }
+    // required position of menu
     const pos = this.props.menuPosition;
+    // true if position falls in bottom half of screen
+    const bottomHalf = pos.y > window.innerHeight / 2;
     // size and position hat and menu
     const psize = this.props.menuHat ? 20 : 0;
-    const pointerPosition = {
+    const pointerPosition = bottomHalf ? {
+      width: `${psize}px`,
+      height: `${psize}px`,
+      left: `${pos.x - 10}px`,
+      top: `${pos.y - (psize * 1.5)}px`,
+    } : {
       width: `${psize}px`,
       height: `${psize}px`,
       left: `${pos.x - 10}px`,
       top: `${pos.y}px`,
     };
-    const menuPosition = {
+    const menuPosition = bottomHalf ? {
+      left: `${pos.x - 10}px`,
+      bottom: `${window.innerHeight - pos.y + psize}px`,
+    } : {
       left: `${pos.x - 10}px`,
       top: `${pos.y + (psize / 2)}px`,
     };

--- a/src/components/Menu/MenuOverlay.js
+++ b/src/components/Menu/MenuOverlay.js
@@ -126,7 +126,7 @@ class MenuOverlay extends Component {
       width: `${psize}px`,
       height: `${psize}px`,
       left: `${pos.x - 10}px`,
-      top: `${pos.y - (psize * 1.5)}px`,
+      top: `${pos.y - psize * 1.5}px`,
     } : {
       width: `${psize}px`,
       height: `${psize}px`,
@@ -138,7 +138,7 @@ class MenuOverlay extends Component {
       bottom: `${window.innerHeight - pos.y + psize}px`,
     } : {
       left: `${pos.x - 10}px`,
-      top: `${pos.y + (psize / 2)}px`,
+      top: `${pos.y + psize / 2}px`,
     };
     // to be called after render, react sucks
     if (!this.measured) {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -11,7 +11,7 @@
   --colors-slightlyDarkGrey: #6B6F7C;
   --colors-grey: #888B96;
   --colors-menutext: #161922;
-  --colors-menutext-disabled: #585B69;
+  --colors-menutext-disabled: #aaa;
   --colors-slightlyLightGrey: #A0A3AE;
   --colors-mediumLightGrey: #C2C5D2;
   --colors-lightGrey: #DFE2EC;


### PR DESCRIPTION
#### Overview

Context menus reposition themselves if they fall in the bottom half of the viewport
( also I removed a lint rule...no mixed operators is dumb. Order of operations are well known. As it stands 1 + 2 * 3 would not be allowed. Lint rules should not change the language. )

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

