### PR TITLE
no symbol picker for top level constructs

### DIFF
--- a/src/components/Inspector/InspectorBlock.js
+++ b/src/components/Inspector/InspectorBlock.js
@@ -320,12 +320,12 @@ export class InspectorBlock extends Component {
             paletteName={palette}
             onSelectColor={this.selectColor}
           />
-          <SBOLPicker
+          {isConstruct && singleInstance && !hasParents ? null : <SBOLPicker
             setText={this.setColorSymbolText}
             current={this.currentRoleSymbol()}
             readOnly={readOnly || isFixed}
             onSelect={this.selectSymbol}
-          />
+          />}
         </div>
         <InspectorRow
           heading={`${type} Rules`}


### PR DESCRIPTION
#### Overview

No symbol picker for construct, rules for constructs was already not visible for constructs.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

