### PR TITLE
list blocks get list glyph that can be overridden in inspector. But y…

### DIFF
--- a/src/components/Inspector/TemplateRules.js
+++ b/src/components/Inspector/TemplateRules.js
@@ -17,7 +17,13 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 
-import { blockFreeze, blockMerge, blockSetHidden, blockSetListBlock } from '../../actions/blocks';
+import {
+  blockFreeze,
+  blockMerge,
+  blockSetHidden,
+  blockSetListBlock,
+  blockSetRole,
+} from '../../actions/blocks';
 import '../../styles/TemplateRules.css';
 import Checkbox from '../formElements/Checkbox';
 
@@ -30,6 +36,7 @@ export class TemplateRules extends Component {
     //blockFreeze: PropTypes.func.isRequired,
     blockSetListBlock: PropTypes.func.isRequired,
     blockSetHidden: PropTypes.func.isRequired,
+    blockSetRole: PropTypes.func.isRequired,
   };
 
   constructor() {
@@ -41,7 +48,10 @@ export class TemplateRules extends Component {
         () => this.props.isConstruct],
       ['list',
         'List Block',
-        value => this.props.blockSetListBlock(this.props.block.id, value),
+        (value) => {
+          this.props.blockSetListBlock(this.props.block.id, value);
+          this.props.blockSetRole(this.props.block.id, value ? 'list' : null);
+        },
         () => this.props.block.isConstruct() || this.props.block.hasSequence()],
       /*
       ['frozen',
@@ -88,4 +98,5 @@ export default connect(mapStateToProps, {
   blockFreeze,
   blockSetListBlock,
   blockSetHidden,
+  blockSetRole,
 })(TemplateRules);

--- a/src/components/Inventory/InventoryGroupRole.js
+++ b/src/components/Inventory/InventoryGroupRole.js
@@ -95,7 +95,10 @@ class InventoryGroupRole extends Component {
     let rules;
     const isList = this.state.current.id === 'list';
     if (isList) {
-      rules = { list: true };
+      rules = {
+        list: true,
+        role: this.state.current.id === 'null' ? null : this.state.current.id,
+      };
     } else {
       rules = {
         role: this.state.current.id === 'null' ? null : this.state.current.id,

--- a/src/components/ui/SBOLPicker.js
+++ b/src/components/ui/SBOLPicker.js
@@ -134,7 +134,7 @@ export default class SBOLPicker extends Component {
     if (this.state.expanded) {
       chips = (
         <div className="dropdown">
-          {symbols.map((symbolObj) => {
+          {symbols.filter(symbolObj => symbolObj.id !== 'list').map((symbolObj) => {
             const { id } = symbolObj;
             return this.makeSymbol(id);
           })}


### PR DESCRIPTION
…ou can never set the list glyph, except by toggling list block state

#### Overview

List blocks get a glyph when dragged into canvas.
You cannot select the list glyph in the symbol picker but it is displayed for list blocks if assigned.
You can override the glyph for list blocks.
When the user toggles the list state of a block it either removes of adds the list glyph depending on list state.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

