### PR TITLE
download construct menu item(s) in constructviewer actually download …

### DIFF
--- a/src/components/Inventory/InventoryProjectTree.js
+++ b/src/components/Inventory/InventoryProjectTree.js
@@ -51,7 +51,7 @@ import '../../styles/InventoryProjectTree.css';
 import Spinner from '../ui/Spinner';
 import Tree from '../ui/Tree';
 import BasePairCount from '../ui/BasePairCount';
-import downloadProject from '../../middleware/utils/downloadProject';
+import { downloadProject } from '../../middleware/utils/downloadProject';
 
 export class InventoryProjectTree extends Component {
   static propTypes = {

--- a/src/components/ProjectHeader.js
+++ b/src/components/ProjectHeader.js
@@ -44,7 +44,7 @@ import {
 import Box2D from '../containers/graphics/geometry/box2d';
 import Vector2D from '../containers/graphics/geometry/vector2d';
 import TitleAndToolbar from '../components/toolbars/title-and-toolbar';
-import downloadProject from '../middleware/utils/downloadProject';
+import { downloadProject } from '../middleware/utils/downloadProject';
 import GlobalNav from './GlobalNav/GlobalNav';
 import ConstructViewer from '../containers/graphics/views/constructviewer';
 

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -70,7 +70,7 @@ import SceneGraph2D from '../scenegraph2d/scenegraph2d';
 import UserInterface from './constructvieweruserinterface';
 import Layout from './layout';
 import TitleAndToolbar from '../../../components/toolbars/title-and-toolbar';
-import downloadProject from '../../../middleware/utils/downloadProject';
+import { downloadConstruct } from '../../../middleware/utils/downloadProject';
 
 
 // static hash for matching viewers to constructs
@@ -844,7 +844,7 @@ export class ConstructViewer extends Component {
         text: 'Download Construct',
         disabled: false,
         action: () => {
-          downloadProject(this.props.currentProjectId, this.props.focus.options);
+          downloadConstruct(this.props.currentProjectId, this.props.constructId, this.props.focus.options);
         },
       },
       {
@@ -908,7 +908,7 @@ export class ConstructViewer extends Component {
         imageURL: '/images/ui/download.svg',
         enabled: true,
         clicked: () => {
-          downloadProject(this.props.currentProjectId, this.props.focus.options);
+          downloadConstruct(this.props.currentProjectId, this.props.constructId, this.props.focus.options);
         },
       },
       {

--- a/src/middleware/utils/downloadProject.js
+++ b/src/middleware/utils/downloadProject.js
@@ -15,9 +15,7 @@
 */
 import { extensionApiPath } from './paths';
 
-export default function downloadProject(projectId, options) {
-  const url = extensionApiPath('genbank', `export/${projectId}`);
-  const postBody = options;
+function downloadViaIFrame(url, postBody) {
   const iframeTarget = `${Math.floor(Math.random() * 10000)}${+Date.now()}`;
 
   // for now use an iframe otherwise any errors will corrupt the page
@@ -51,5 +49,17 @@ export default function downloadProject(projectId, options) {
     document.body.removeChild(form);
     document.body.removeChild(iframe);
   }, 60 * 1000);
+}
+
+export function downloadProject(projectId, options) {
+  const url = extensionApiPath('genbank', `export/${projectId}`);
+  const postBody = options;
+  downloadViaIFrame(url, postBody);
+}
+
+export function downloadConstruct(projectId, constructId, options) {
+  const url = extensionApiPath('genbank', `export/${projectId}/${constructId}`);
+  const postBody = options;
+  downloadViaIFrame(url, postBody);
 }
 


### PR DESCRIPTION
…the construct, not the entire project

#### Overview

I don't know GB format so I can't verify but looks like you get the expected smaller file with construct versus project.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

