### PR TITLE
disallow adding children to hidden blocks

### DIFF
--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -360,7 +360,7 @@ export class ConstructViewer extends Component {
     const block = this.props.blocks[blockId];
     invariant(block, 'expected to get a block');
     // list blocks cannot have children
-    return !block.isList();
+    return !block.isList() && !block.isHidden();
   }
 
   /**


### PR DESCRIPTION
#### Overview

Cannot drop blocks onto hidden blocks


#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

