### PR TITLE
Focus pocus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 node_modules
 npm-debug.log
 test-e2e/screenshots

--- a/src/components/Inspector/InspectorBlock.js
+++ b/src/components/Inspector/InspectorBlock.js
@@ -320,16 +320,16 @@ export class InspectorBlock extends Component {
             paletteName={palette}
             onSelectColor={this.selectColor}
           />
-          {isConstruct && singleInstance && !hasParents ? null : <SBOLPicker
+          {singleInstance && hasParents ? <SBOLPicker
             setText={this.setColorSymbolText}
             current={this.currentRoleSymbol()}
             readOnly={readOnly || isFixed}
             onSelect={this.selectSymbol}
-          />}
+          /> : null}
         </div>
         <InspectorRow
           heading={`${type} Rules`}
-          condition={!isConstruct && singleInstance}
+          condition={!isConstruct && singleInstance && hasParents}
         >
           <TemplateRules
             block={instances[0]}

--- a/src/components/toolbars/title-and-toolbar.js
+++ b/src/components/toolbars/title-and-toolbar.js
@@ -73,7 +73,7 @@ class TitleAndToolbar extends Component {
       disabled: !!this.props.noHover,
     };
     return (
-      <div className="title-and-toolbar">
+      <div className="title-and-toolbar" onClick={this.props.itemActivated}>
         <div
           className="title"
           {...disabledProp}

--- a/src/containers/orders/constructpreview.js
+++ b/src/containers/orders/constructpreview.js
@@ -113,7 +113,7 @@ class ConstructPreview extends Component {
    * this is because the layout object thinks we are construct viewer. At the very least we have to
    * return an object with a .metadata property
    */
-  getProject() {
+  getProject() { //eslint-disable-line class-methods-use-this
     return {
       metadata: {
 

--- a/src/containers/orders/constructpreview.js
+++ b/src/containers/orders/constructpreview.js
@@ -109,6 +109,18 @@ class ConstructPreview extends Component {
     this.setState({ index });
   };
 
+  /**
+   * this is because the layout object thinks we are construct viewer. At the very least we have to
+   * return an object with a .metadata property
+   */
+  getProject() {
+    return {
+      metadata: {
+
+      },
+    };
+  }
+
   get dom() {
     return ReactDOM.findDOMNode(this);
   }

--- a/test-e2e/tests/deleteproject.js
+++ b/test-e2e/tests/deleteproject.js
@@ -12,7 +12,12 @@ module.exports = {
     openInventoryPanel(browser, 'Projects')
     browser
       .waitForElementPresent('.inventory-project-tree .expando', 5000, 'expected project tree with one project')
-      .assert.countelements('.inventory-project-tree .expando', 1);
+      .assert.countelements('.inventory-project-tree .expando', 1)
+      .assert.countelements('[data-testid^="project"]', 1)
+      .pause(1000)
+      .click('[data-testid="NewProjectButton"')
+      .pause(3000)
+      .assert.countelements('[data-testid^="project"]', 2);
 
     rightClickAt(browser, '.inventory-project-tree .expando', 40, 10);
     clickMenuNthItem(browser, 8);
@@ -20,9 +25,11 @@ module.exports = {
     browser
       // wait for confirmation dialog and accept
       .waitForElementPresent('.ok-cancel-form button[type="submit"]', 5000, 'expected confirmation dialog')
-      .pause(1000)
+      .pause(3000)
       .click('.ok-cancel-form button[type="submit"]')
-      .waitForElementNotPresent('.inventory-project-tree .expando', 5000, 'expected no projects')
+      .waitForElementNotPresent('.ok-cancel-form button[type="submit"]', 5000, 'expected confirmation dialog to go away')
+      .pause(3000)
+      .assert.countelements('[data-testid^="project"]', 1)
       .end();
 
   }

--- a/test-e2e/tests/select-empty-blocks.js
+++ b/test-e2e/tests/select-empty-blocks.js
@@ -11,7 +11,7 @@ module.exports = {
     homepageRegister(browser);
     testProject(browser);
     openNthBlockContextMenu(browser, '.construct-viewer[data-index="0"] .sceneGraph', 5);
-    clickNthContextMenuItem(browser, 6);
+    clickNthContextMenuItem(browser, 7);
     browser
       .pause(1000)
       // ensure we have all 3 blocks elements selected

--- a/test-e2e/tests/symbol-picker.js
+++ b/test-e2e/tests/symbol-picker.js
@@ -15,7 +15,7 @@ module.exports = {
     .waitForElementPresent('.SBOLPicker', 1000, 'expected a symbol picker')
     .click('.SBOLPicker')
     .waitForElementPresent('.SBOLPicker .dropdown')
-    .assert.countelements('.SBOLPicker .RoleSvg', 16)
+    .assert.countelements('.SBOLPicker .RoleSvg', 15)
     .end();
   },
 };


### PR DESCRIPTION
#### Overview

No symbol picker / rules for constructs when focused. Also, clicking anywhere in the construct title gives the focus and allows for activation of the context menu.
Also, all e2e tests as passing.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

