### PR TITLE
require new GSL Editor version for new UX

### DIFF
--- a/server/extensions/package.json
+++ b/server/extensions/package.json
@@ -7,7 +7,7 @@
     "testPrivate" : "../../extensions/testPrivate",
     "testErrorServer" : "../../extensions/testErrorServer",
     "SequenceDetail" : "IsaacLuo/onion2#8f03cd9d4820b9e98965dc945539afed9b9205cb",
-    "GC-GSL-Editor" : "autodesk-bionano/gc-gsl-editor#v1.0.5",
+    "GC-GSL-Editor" : "autodesk-bionano/gc-gsl-editor#v1.1.0",
     "GC-Sequence-Viewer": "duncanmeech/sequence-viewer"
   }
 }


### PR DESCRIPTION
#### Overview

This change bumps the version of the GSL Editor to `v1.1.0`, which is compatible with the new UI elements of the new GC UX.

#### Type of change (bug fix, feature, docs, UI, etc.)

Fixes the menus in the GSL Editor Console

#### Issue

#1391 