### PR TITLE
v1.1.1 of GSL Editor handles empty GSL code files gracefully

### DIFF
--- a/server/extensions/package.json
+++ b/server/extensions/package.json
@@ -7,7 +7,7 @@
     "testPrivate" : "../../extensions/testPrivate",
     "testErrorServer" : "../../extensions/testErrorServer",
     "SequenceDetail" : "IsaacLuo/onion2#8f03cd9d4820b9e98965dc945539afed9b9205cb",
-    "GC-GSL-Editor" : "autodesk-bionano/gc-gsl-editor#v1.1.0",
+    "GC-GSL-Editor" : "autodesk-bionano/gc-gsl-editor#v1.1.1",
     "GC-Sequence-Viewer": "duncanmeech/sequence-viewer"
   }
 }


### PR DESCRIPTION
#### Overview

`v1.1.1` of the GSL Editor will detect if a GSL Project code file is empty and load the default code instead.

#### Type of change (bug fix, feature, docs, UI, etc.)

Bug workaround - Still unclear why GSL code profile files aren't being saved properly in some cases.

#### Breaking Changes

None

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

