### PR TITLE
logging improvements

### DIFF
--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -17,6 +17,7 @@ webapp:
     BNR_ENV_TAG: ${BNR_ENV_TAG}
     BNR_ENV_URL_SUFFIX: ${BNR_ENV_URL_SUFFIX}
     EMAIL: ${EMAIL}
+    VERBOSE_REQUEST_LOGS: ${VERBOSE_REQUEST_LOGS}
   command:
     npm run server-auth
   log_driver: json-file

--- a/server/server.js
+++ b/server/server.js
@@ -19,7 +19,6 @@ import path from 'path';
 import bodyParser from 'body-parser';
 import compression from 'compression';
 import express from 'express';
-import morgan from 'morgan';
 
 import colors from 'colors/safe';
 
@@ -34,6 +33,7 @@ import { registrationHandler } from './user/updateUserHandler';
 import userRouter from './user/userRouter';
 import { pruneUserObject } from './user/utils';
 import checkPortFree from './utils/checkPortFree';
+import logger from './utils/logConfig';
 import customErrorMiddleware from './errors/customErrorMiddleware';
 import lastDitchErrorMiddleware from './errors/lastDitchErrorMiddleware';
 
@@ -65,19 +65,7 @@ app.use(bodyParser.json({
 }));
 
 //HTTP logging middleware
-const logLevel = process.env.NODE_ENV === 'production' ? 'combined' : 'dev';
-app.use(morgan(logLevel, {
-  skip: (req, res) => {
-    if (req.path.indexOf('browser-sync') >= 0 || req.path.indexOf('__webpack') >= 0) {
-      return true;
-    }
-    //skip logging in test environment, unless DEBUG is set
-    if (process.env.NODE_ENV === 'test' && !process.env.DEBUG) {
-      return true;
-    }
-    return false;
-  },
-}));
+app.use(logger);
 
 // view engine setup
 app.set('views', pathContent);

--- a/server/utils/logConfig.js
+++ b/server/utils/logConfig.js
@@ -1,0 +1,57 @@
+/*
+ Copyright 2016 Autodesk,Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import morgan from 'morgan';
+
+const devLogFormat = ':method :url :status :response-time ms :res[content-length]';
+const expandedLogFormat = ':date[iso] :status :response-time ms :res[content-length] - ":method :url HTTP/:http-version" - ":referrer" - ":user-agent"';
+const prodLogFormat = ':date[iso] :status :response-time ms :res[content-length] - ":method :url" - ":referrer" - ":user-agent"';
+
+// compile them all so changes to the non-local formats aren't first complied on deployment
+const devLogger = morgan.compile(devLogFormat);
+const expandedLogger = morgan.compile(expandedLogFormat);
+const prodLogger = morgan.compile(prodLogFormat);
+
+// assumes a local developer won't set NODE_ENV
+function chooseLogFormat() {
+  console.log(`NODE_ENV: ${process.env.NODE_ENV}`);
+  console.log(`VERBOSE_REQUEST_LOGS: ${process.env.VERBOSE_REQUEST_LOGS}`);
+
+  if (process.env.VERBOSE_REQUEST_LOGS === 'true') {
+    return expandedLogger;
+  }
+
+  if (process.env.NODE_ENV === 'production') {
+    return prodLogger;
+  }
+
+  if ((process.env.NODE_ENV !== 'dev') && (process.env.NODE_ENV !== 'qa') && (process.env.NODE_ENV !== 'test')) {
+    console.error(`unrecognized 'NODE_ENV' value: ${process.env.NODE_ENV}`);
+  }
+
+  return devLogger;
+}
+
+export default morgan(chooseLogFormat(), {
+  skip: (req, res) => {
+    if ((req.path.indexOf('browser-sync') >= 0) || (req.path.indexOf('__webpack') >= 0)) {
+      return true;
+    }
+
+    //skip logging in test environment, unless DEBUG is set
+    return (process.env.NODE_ENV === 'test') && !process.env.DEBUG;
+  },
+});


### PR DESCRIPTION
#### Overview

The previous logging configuration was deficient because `NODE_ENV=dev` in both the local development environment as well as the deployed `dev` environment. The deployed `dev` environment is where we want the most verbose logging. Response times were also not logged in the `production` environment.

This commit provides the following:

 * ability to enable "verbose" logging in any environment with `process.env.VERBOSE_REQUEST_LOGS == 'true'`
 * abbreviated request logging in local environments
 * addition of response time to `production` logs
 * change to ISO date format
 * remove `remote address`, `remote user`, and `HTTP version` from production logs
    * `remote address` is always one of the two load balancers
    * `remote user` was always null
* reorder logging fields for easier filtering

#### Type of change (bug fix, feature, docs, UI, etc.)

feature

#### Breaking Changes

none

#### Issue

#1609 