### PR TITLE
Project header tweak

### DIFF
--- a/src/styles/ProjectHeader.css
+++ b/src/styles/ProjectHeader.css
@@ -3,8 +3,10 @@
 .ProjectHeader {
   margin-left: 16px;
   width: calc(100% - 27px);
-  height: var(--GlobalNav-height-chrome);
+  height: 41px;
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
+  flex-direction: column;
+  justify-content: flex-end;
 }

--- a/src/styles/SceneGraphPage.css
+++ b/src/styles/SceneGraphPage.css
@@ -93,7 +93,7 @@
 }
 
 .construct-viewer {
-  margin: 1rem 1rem 0 2rem;
+  margin: 0 1rem 0 2rem;
   width: calc(100% - 3rem);
   background: transparent;
   position: relative;

--- a/src/styles/inline-editor.css
+++ b/src/styles/inline-editor.css
@@ -10,7 +10,7 @@
 /*styles for specific inline editing contexts*/
 .inline-editor-project {
   text-indent: 5px;
-  font-size: 1.5rem;
+  font-size: 16px;
   font-family: Helvetica;
 }
 .inline-editor-construct-title {

--- a/src/styles/inter-construct-droptarget.css
+++ b/src/styles/inter-construct-droptarget.css
@@ -5,14 +5,16 @@
   height: 10px;
   width: calc(100% - 3rem);
   border-top: 10px solid transparent;
-  margin: 1rem 1rem 0 2rem;
+  margin: 0.75rem 1rem 1rem 2rem;
 
   &:last-child {
     height: 400px;
   }
 
   &:first-child {
-    margin-top: 0;
+    margin: 0 1rem 2px 2rem;
+    border-top-width: 7px;
+    height: 7px;
   }
 }
 


### PR DESCRIPTION
#### Overview

Tweak project header and squeeze first inter construct drop zone so that the first construct lines up with top of inspector / inventory.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

