### PR TITLE
Lock symbol

### DIFF
--- a/src/components/Inventory/InventoryGroup.js
+++ b/src/components/Inventory/InventoryGroup.js
@@ -76,6 +76,9 @@ class InventoryGroup extends Component {
    * when blocks are dropped
    */
   onBlockDropped = (globalPosition, payload) => {
+    if (this.props.tabInfo.type !== 'projects') {
+      return;
+    }
     // create a new project and add blocks as a construct
     // create project and add a default construct
     const project = this.props.projectCreate();
@@ -105,11 +108,15 @@ class InventoryGroup extends Component {
    * drag enter, only valid for certain tabs
    */
   onDragEnter = () => {
-    this.setState({ dragInside: true });
+    if (this.props.tabInfo.type === 'projects') {
+      this.setState({ dragInside: true });
+    }
   };
 
   onDragLeave = () => {
-    this.setState({ dragInside: false });
+    if (this.props.tabInfo.type === 'projects') {
+      this.setState({ dragInside: false });
+    }
   };
 
   /**

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -59,7 +59,6 @@ import {
   detailViewSelectExtension,
   inspectorSelectTab,
 } from '../../../actions/ui';
-import RoleSvg from '../../../components/RoleSvg';
 import { role as roleDragType } from '../../../constants/DragTypes';
 import { blockGetComponentsRecursive, blockGetParents } from '../../../selectors/blocks';
 import { projectGet } from '../../../selectors/projects';

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -616,25 +616,6 @@ export class ConstructViewer extends Component {
     return this.props.construct.id === this.props.focus.constructId;
   }
 
-  lockIcon() {
-    if (!this.props.construct.isFrozen()) {
-      return null;
-    }
-    const isFocused = this.props.construct.id === this.props.focus.constructId;
-    const classes = `lockIcon${isFocused ? '' : ' sceneGraph-dark'}`;
-    return (
-      <div className={classes}>
-        <RoleSvg
-          symbolName="lock"
-          color={this.props.construct.getColor()}
-          width="14px"
-          height="14px"
-          fill={this.props.construct.getColor()}
-        />
-      </div>
-    );
-  }
-
   /**
    * toggle the side panels
    */
@@ -939,6 +920,12 @@ export class ConstructViewer extends Component {
         },
       },
       {
+        text: this.props.construct.isFrozen() ? 'Locked' : 'Unlocked',
+        imageURL: this.props.construct.isFrozen() ? '/images/ui/lock-locked.svg' : '/images/ui/lock-unlocked.svg',
+        enabled: false,
+        clicked: () => {},
+      },
+      {
         text: 'Order DNA',
         imageURL: '/images/ui/order.svg',
         enabled: this.allowOrder(),
@@ -1004,7 +991,6 @@ export class ConstructViewer extends Component {
             itemActivated={() => this.props.focusConstruct(this.props.constructId)}
           />
         </div>
-        {this.lockIcon()}
       </div>
     );
   }

--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -383,7 +383,8 @@ export class ConstructViewer extends Component {
   blockContextMenuItems = () => {
     const singleBlock = this.props.focus.blockIds.length === 1;
     const firstBlock = this.props.blocks[this.props.focus.blockIds[0]];
-    const canListify = singleBlock && !firstBlock.hasSequence();
+    const isBackbone = firstBlock ? firstBlock.rules.role === 'backbone' : false;
+    const canListify = singleBlock && !firstBlock.hasSequence() && !isBackbone;
     const listItems = singleBlock ? [
       {
         text: `Convert to ${firstBlock.isList() ? ' Normal Block' : ' List Block'}`,

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -725,7 +725,7 @@ export default class Layout {
     let rowIndex = 0;
 
     // display only non hidden blocks
-    const components = this.showHidden ? ct.components : ct.components.filter(blockId => !this.blockIsHidden(blockId));
+    const components = this.showHidden ? [...ct.components] : ct.components.filter(blockId => !this.blockIsHidden(blockId));
 
     if (this.constructViewer.isCircularConstruct() && this.rootLayout) {
       // put a reference to the first component ( the backbone block ) into block hash

--- a/src/containers/graphics/views/layout.js
+++ b/src/containers/graphics/views/layout.js
@@ -937,8 +937,8 @@ export default class Layout {
     // position and size vertical bar
     const heightUsed = yp - startY + kT.blockH;
     let barHeight = Math.max(kT.rowBarH + kT.blockH, heightUsed - kT.blockH + kT.rowBarH);
-    // if the height is small just make zero since its not needed
-    if (barHeight <= kT.rowBarH) {
+    // do not display if no blocks
+    if (!components.length) {
       barHeight = 0;
     }
     this.vertical.set({

--- a/src/styles/SceneGraphPage.css
+++ b/src/styles/SceneGraphPage.css
@@ -93,8 +93,8 @@
 }
 
 .construct-viewer {
-  margin: 1rem 1rem 0 2rem;
-  width: calc(100% - 3rem);
+  margin: 1rem 1rem 0 1rem;
+  width: calc(100% - 2rem);
   background: transparent;
   position: relative;
 

--- a/src/styles/inter-construct-droptarget.css
+++ b/src/styles/inter-construct-droptarget.css
@@ -3,9 +3,9 @@
 .inter-construct-drop-target {
   box-sizing: border-box;
   height: 10px;
-  width: calc(100% - 3rem);
+  width: calc(100% - 2rem);
   border-top: 10px solid transparent;
-  margin: 1rem 1rem 0 2rem;
+  margin: 1rem 1rem 0 1rem;
 
   &:last-child {
     height: 400px;


### PR DESCRIPTION
#### Overview

Lock symbols moves to toolbar ( doesn't do anything but shows locked / unlocked state ).
Margins on construct viewer shrink since space is not required for lock icon.

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

