### PR TITLE
deep set projectId when add a block to a block

### DIFF
--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -620,9 +620,8 @@ export const blockAddComponent = (blockId, componentId, index = -1, forceProject
     if (componentProjectId !== nextParentProjectId || contentProjectIds.some(compProjId => compProjId !== nextParentProjectId)) {
       invariant(forceProjectId === true && !componentProjectId && contentProjectIds.every(compProjId => !compProjId), 'cannot add component with different projectId! set forceProjectId = true to overwrite.');
 
-      //there may be scenarios where we are adding to a detached block, so lets avoid the error when next parent has no project
       if (nextParentProjectId) {
-        dispatch(blockSetProject(componentId, nextParentProjectId, false));
+        dispatch(blockSetProject(componentId, nextParentProjectId, true));
       }
     }
 


### PR DESCRIPTION
#### Overview

when adding a block to a block, sets the projectid of all children 

#### Type of change (bug fix, feature, docs, UI, etc.)

fix

#### Breaking Changes

none

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

