### PR TITLE
added explicit separate compose file so ecs build can be done alongside prevous

### DIFF
--- a/docker-compose-quickstart-ecs.yml
+++ b/docker-compose-quickstart-ecs.yml
@@ -21,6 +21,7 @@ webapp:
   command:
     npm run server-auth
   log_driver: json-file
-  restart: always
+  # 8 GB RAM for gc docker stats as of 22-Mar-17 show max mem usage of 6.5 GB in dev
+  mem_limit: 8400000000 
   ports:
-    - "3000:3000"
+    - "3000"


### PR DESCRIPTION
#### Overview
To make cut-over to ecs-deployment adding both ecs-based and non-ecs-based docker-compose file. Main difference is the usage of dynamic host ports in the ecs case. 


#### Type of change (bug fix, feature, docs, UI, etc.)
deployment


#### Breaking Changes
None


#### Requirements
None
- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information
future PR will remove non-ecs files when cut-over is complete


#### Issue

