### PR TITLE
fix for deploy error with internal dns names to loadbalancer

### DIFF
--- a/docker-compose-feature-quickstart.yml
+++ b/docker-compose-feature-quickstart.yml
@@ -7,13 +7,15 @@ webapp:
      - "3333:3333"
   environment:
     PORT: 3333
-    API_END_POINT: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:8080/api
+    #lb dns names always have the environment included
+    API_END_POINT: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:8080/api
     HOST_URL: https://gctor-feature${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com
     NODE_ENV: ${NODE_ENV}
     GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
     CAPTCHA_SECRET_REGISTER: ${CAPTCHA_SECRET_REGISTER}
     NO_DOCKER: "true"
-    STORAGE_API: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
+    #lb dns names always have the environment included
+    STORAGE_API: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:4747/api
     AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
     EMAIL: ${EMAIL}

--- a/docker-compose-quickstart-ecs.yml
+++ b/docker-compose-quickstart-ecs.yml
@@ -4,13 +4,15 @@ webapp:
     service: webapp
   image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
   environment:
-    API_END_POINT: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:8080/api
+    #lb dns names always have the environment included
+    API_END_POINT: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:8080/api
     HOST_URL: https://geneticconstructor${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com
     NODE_ENV: ${NODE_ENV}
     GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
     CAPTCHA_SECRET_REGISTER: ${CAPTCHA_SECRET_REGISTER}
     NO_DOCKER: "true"
-    STORAGE_API: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
+    #lb dns names always have the environment included
+    STORAGE_API: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:4747/api
     AWS_ACCESS_KEY_ID: ${GC_AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${GC_AWS_SECRET_ACCESS_KEY}
     BNR_ENVIRONMENT: ${BNR_ENVIRONMENT}

--- a/docker-compose-quickstart.yml
+++ b/docker-compose-quickstart.yml
@@ -4,13 +4,15 @@ webapp:
     service: webapp
   image: quay.io/autodesk_bionano/gctor_webapp${BNR_ENV_TAG}
   environment:
-    API_END_POINT: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:8080/api
+    #lb dns names always have the environment included
+    API_END_POINT: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:8080/api
     HOST_URL: https://geneticconstructor${BNR_ENV_URL_SUFFIX}.bionano.autodesk.com
     NODE_ENV: ${NODE_ENV}
     GITHUB_ACCESS_TOKEN: ${GITHUB_ACCESS_TOKEN}
     CAPTCHA_SECRET_REGISTER: ${CAPTCHA_SECRET_REGISTER}
     NO_DOCKER: "true"
-    STORAGE_API: http://internal-lb${BNR_ENV_URL_SUFFIX}.bionano.bio:4747/api
+    #lb dns names always have the environment included
+    STORAGE_API: http://internal-lb.${BNR_ENVIRONMENT}.bionano.bio:4747/api
     AWS_ACCESS_KEY_ID: ${GC_AWS_ACCESS_KEY_ID}
     AWS_SECRET_ACCESS_KEY: ${GC_AWS_SECRET_ACCESS_KEY}
     BNR_ENVIRONMENT: ${BNR_ENVIRONMENT}


### PR DESCRIPTION
#### Overview
Change lb dns entries to always contain environment name via ".${BNR_ENVIRONMENT}."
This is the preferred change as the names for internal dns entries of the load balancer *alwasy* contain the environment entry, such as:
internal-lb.dev.bionano.bio
internal-lb.qa.bionano.bio
internal-lb.prod.bionano.bio

The prevous env entry `${BNR_ENV_URL_SUFFIX}` will collapse to an empty string prod environment. This env is meant for public facing urls.

#### Type of change (bug fix, feature, docs, UI, etc.)
bug fix
deployment


#### Breaking Changes
none


#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

