### PR TITLE
Fixed bug with converting name in Snapgene Import

### DIFF
--- a/server/extensions/native/genbank/genbank_import.py
+++ b/server/extensions/native/genbank/genbank_import.py
@@ -200,7 +200,7 @@ def create_root_block_from_genbank(gb, sequence, import_type = "normal"):
 def convert_block_name(f, block, import_type):
     if import_type == "snapgene_vector":
         if "label" in f.qualifiers:
-            block["metadata"]["name"] = f.qualifiers["label"]
+            block["metadata"]["name"] = f.qualifiers["label"][0]
             block["metadata"]["genbank"]["name_source"] = "label"
             return
 


### PR DESCRIPTION
#### Overview
Python was returning an array in the name, instead of the string.


#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

