### PR TITLE
merge v0.10.5 patch release tag back into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "genetic-constructor",
-  "version": "0.10.3",
+  "version": "0.10.5",
   "description": "Genetic Constructor",
   "main": "index.js",
   "scripts": {

--- a/src/components/formElements/Captcha.js
+++ b/src/components/formElements/Captcha.js
@@ -56,7 +56,7 @@ export default class Captcha extends Component {
   };
 
   static defaultProps = {
-    sitekey: '6LdvyREUAAAAAKr6h7kyBzioJsXPGNKjW9r21WSh',
+    sitekey: '6LcJXRoUAAAAAKaVC2gACevP7RGA9onCKQXM_Qe6',
     theme: 'light',
     type: 'image',
     size: 'normal',


### PR DESCRIPTION
`QA` was tagged with `v0.10.5` and subsequently released to `PROD` in order to accommodate the change in the Captcha secret after it was compromised.