### PR TITLE
Blast fixes (only run on leaf nodes)

### DIFF
--- a/extensions/blast/README.md
+++ b/extensions/blast/README.md
@@ -1,0 +1,9 @@
+BLAST Extension
+
+Creates a Job Processor, which runs a BLAST query for a given sequence and returns a project with the BLAST results in a list block
+
+Provides a list item extension, added to the block context menu in Constructor
+
+Exposes a router to POST and GET jobs
+
+Note - this extension is not bundled, as it is currently directly mounted into the app.

--- a/extensions/blast/blockMenuItem.js
+++ b/extensions/blast/blockMenuItem.js
@@ -17,7 +17,7 @@
 constructor.extensions.register('blast', 'menu:block',
   (singleBlockSelected, block) => [{
     text: 'BLAST for similar sequences',
-    disabled: !singleBlockSelected || !block.hasSequence(),
+    disabled: !singleBlockSelected || !block.hasSequence() || block.hasContents(),
     action: () =>
       block.getSequence()
       .then(sequence => constructor.jobs.jobCreate(block.projectId, 'blast', { id: block.id, sequence }))
@@ -27,6 +27,9 @@ constructor.extensions.register('blast', 'menu:block',
           metadata: { name: `BLAST: ${block.getName()}` },
           jobId,
           components: [],
+          sequence: {
+            annotations: [],
+          },
         });
 
         constructor.api.projects.projectAddConstruct(block.projectId, construct.id);

--- a/src/actions/blocks.js
+++ b/src/actions/blocks.js
@@ -73,6 +73,8 @@ const _assertUserOwnsBlock = (state, blockId, options) => {
 
 const _assertBlockNotFixed = block => invariant(!block.isFixed(), 'cannot mutate fixed block');
 
+const _assertBlockIsLeaf = block => invariant(!block.hasContents(), 'block must not have children or list options');
+
 const classifyBlockIfNeeded = input => (input instanceof Block) ? input : new Block(input);
 
 /**************************************
@@ -839,6 +841,7 @@ export const blockRemoveAnnotation = (blockId, annotation) => (dispatch, getStat
  */
 export const blockGetSequence = blockId => (dispatch, getState) => {
   const block = _getBlock(getState(), blockId);
+  _assertBlockIsLeaf(block);
   return block.getSequence();
 };
 
@@ -852,8 +855,8 @@ export const blockGetSequence = blockId => (dispatch, getState) => {
  */
 export const blockSetSequence = (blockId, sequence, useStrict) => (dispatch, getState) => {
   const oldBlock = _getBlock(getState(), blockId);
-
   _assertBlockNotFixed(oldBlock);
+  _assertBlockIsLeaf(oldBlock);
 
   return oldBlock.setSequence(sequence, useStrict)
   .then((block) => {

--- a/src/models/Block.js
+++ b/src/models/Block.js
@@ -176,13 +176,14 @@ export default class Block extends Instance {
    * @returns {boolean}
    */
   hasContents() {
-    return this.components.length || Object.keys(this.options).length;
+    return this.components.length > 0 || Object.keys(this.options).length > 0;
   }
 
   //isSpec() can't exist here, since dependent on children. use selector blockIsSpec instead.
 
   /**
    * Check if Block is a construct (it has components)
+   * todo - rename isParentBlock()
    * @method isConstruct
    * @memberOf Block
    * @returns {boolean}
@@ -527,8 +528,6 @@ export default class Block extends Instance {
   /************
    components
    ************/
-
-  //future - account for block.rules.filter
 
   /**
    * Adds a component by ID

--- a/src/models/Instance.js
+++ b/src/models/Instance.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import invariant from 'invariant';
-import { assign, cloneDeep, merge } from 'lodash';
+import { assign, cloneDeep, merge, mergeWith } from 'lodash';
 
 import InstanceSchema from '../schemas/Instance';
 import ParentSchema from '../schemas/Parent';
@@ -82,7 +82,7 @@ export default class Instance extends Immutable {
     let clone;
 
     if (parentInfo === null) {
-      clone = merge(cloned, overwrites);
+      clone = mergeWith(cloned, overwrites, mergeCustomizer);
     } else {
       const parentObject = Object.assign({
         id: cloned.id,
@@ -97,12 +97,18 @@ export default class Instance extends Immutable {
       const parents = [parentObject, ...cloned.parents];
 
       //unclear why, but merging parents was not overwriting the clone, so shallow assign parents specifically
-      clone = Object.assign(merge(cloned, overwrites), { parents });
+      clone = mergeWith(cloned, overwrites, { parents }, mergeCustomizer);
     }
 
     //unset the ID, so we make it fresh
     delete clone.id;
 
     return new this.constructor(clone);
+  }
+}
+
+function mergeCustomizer(objValue, srcValue) {
+  if (srcValue instanceof Array) {
+    return srcValue;
   }
 }

--- a/test/models/Block/Clone.spec.js
+++ b/test/models/Block/Clone.spec.js
@@ -1,4 +1,5 @@
 import { expect, assert } from 'chai';
+import _ from 'lodash';
 import Block from '../../../src/models/Block';
 import Project from '../../../src/models/Project';
 import { testUserId } from '../../constants';
@@ -23,6 +24,20 @@ describe('Model', () => {
         assert(cloned.parents.length === 1, 'should have parent');
         expect(cloned.parents[0].projectId).to.equal(dummyProject.id);
         expect(cloned.parents[0].id).to.equal(block.id);
+        expect(cloned.projectId).to.eql(null);
+
+        const grandchild = cloned.clone({ owner: testUserId, version: 0 });
+
+        expect(grandchild.id).to.not.equal(block.id);
+        expect(grandchild.id).to.not.equal(cloned.id);
+        assert(grandchild.parents.length === 2, 'should have 2 parents');
+
+        //newest parent first
+        expect(grandchild.parents[0].projectId).to.equal(null);
+        expect(grandchild.parents[0].id).to.equal(cloned.id);
+
+        expect(grandchild.parents[1].projectId).to.equal(dummyProject.id);
+        expect(grandchild.parents[1].id).to.equal(block.id);
       });
 
       it('clone(null) should change the ID, or add to history', () => {
@@ -37,7 +52,36 @@ describe('Model', () => {
         const cloned = frozen.clone(null);
         assert(!cloned.isFrozen(), 'should not be frozen after cloning');
       });
-    });
 
+      it('clone() with overrides should override the initial object', () => {
+        const oldName = 'oldness';
+        const newName = 'newness';
+        const overwrite = {
+          metadata: { name: newName },
+        };
+        const overWriteCheck = _.merge({}, overwrite);
+
+        const source = new Block({
+          metadata: {
+            name: oldName,
+          },
+        });
+        const clone = source.clone(null, overwrite);
+
+        expect(source.metadata.name).to.equal(oldName);
+        expect(clone.metadata.name).to.equal(newName);
+        expect(overwrite).to.eql(overWriteCheck);
+      });
+
+      it('clone() with empty array should override to empty array, not merge', () => {
+        const source = new Block({
+          components: [1, 2, 3].map(() => (new Block()).id),
+        });
+        const clone = source.clone(null, {
+          components: [],
+        });
+        expect(clone.components).to.eql([]);
+      });
+    });
   });
 });


### PR DESCRIPTION
#### Overview

- Prevent blast on list blocks / parent blocks
- remove annotations on starting blast
- Update cloning behavior to properly handle overwrites with empty arrays
- add basic docs for blast extension

#### Type of change (bug fix, feature, docs, UI, etc.)



#### Breaking Changes



#### Requirements

- [x] Adds a test (for features + fixes)
- [x] Docs updated (for features + fixes)

#### Other information



#### Issue

replace #1735 