### PR TITLE
(fix) catch when extension menu:block render function not exist

### DIFF
--- a/src/containers/graphics/views/constructviewer.js
+++ b/src/containers/graphics/views/constructviewer.js
@@ -415,7 +415,9 @@ export class ConstructViewer extends Component {
     }] : [];
 
 
-    const extensionsWithBlockMenus = extensionsByRegion('menu:block').map(manifest => manifest.render['menu:block'](singleBlock, firstBlock));
+    const extensionsWithBlockMenus = extensionsByRegion('menu:block')
+    .filter(manifest => manifest.render['menu:block'])
+    .map(manifest => manifest.render['menu:block'](singleBlock, firstBlock));
 
     const extensionMenuItems = extensionsWithBlockMenus.length > 0 ? [
       {},


### PR DESCRIPTION
#### Overview

when extensions are in weird state, (e.g. not registering properly), handle block menu item extensions not rendering properly

#### Type of change (bug fix, feature, docs, UI, etc.)

fix

#### Breaking Changes

none

#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information

fixes some failing e2e tests, e.g. when blast installed improperly

#### Issue

