### PR TITLE
fix merge error. avoid setup twice on start-auth

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -16,7 +16,9 @@ let processes = [];
 
 async function start() {
   try {
-    processes = await run(setup);
+    if (!process.env.CONSTRUCTOR_SKIP_SETUP) {
+      processes = await run(setup);
+    }
 
     console.log(colors.blue(`Bundling application with Webpack [${DEBUG ? 'dev' : 'release'}] (this may take a moment)...`));
 


### PR DESCRIPTION
#### Overview

setup part of script was running twice on `start-auth` due to merge regression

#### Type of change (bug fix, feature, docs, UI, etc.)

fix

#### Breaking Changes



#### Requirements

- [ ] Adds a test (for features + fixes)
- [ ] Docs updated (for features + fixes)

#### Other information



#### Issue

