### PR TITLE
Blast Menu UI Tweaks

### DIFF
--- a/extensions/blast/blockMenuItem.js
+++ b/extensions/blast/blockMenuItem.js
@@ -17,6 +17,7 @@
 constructor.extensions.register('blast', 'menu:block',
   (singleBlockSelected, block) => [{
     text: 'BLAST for similar sequences',
+    indent: true,
     disabled: !singleBlockSelected || !block.hasSequence() || block.hasContents() || block.sequence.length <= 10,
     action: () =>
       block.getSequence()

--- a/extensions/blast/blockMenuItem.js
+++ b/extensions/blast/blockMenuItem.js
@@ -16,7 +16,7 @@
 
 constructor.extensions.register('blast', 'menu:block',
   (singleBlockSelected, block) => [{
-    text: 'BLAST for similar sequences',
+    text: 'BLAST',
     indent: true,
     disabled: !singleBlockSelected || !block.hasSequence() || block.hasContents() || block.sequence.length <= 10,
     action: () =>

--- a/extensions/blast/blockMenuItem.js
+++ b/extensions/blast/blockMenuItem.js
@@ -17,7 +17,6 @@
 constructor.extensions.register('blast', 'menu:block',
   (singleBlockSelected, block) => [{
     text: 'BLAST',
-    indent: true,
     disabled: !singleBlockSelected || !block.hasSequence() || block.hasContents() || block.sequence.length <= 10,
     action: () =>
       block.getSequence()

--- a/src/components/Menu/MenuItem.js
+++ b/src/components/Menu/MenuItem.js
@@ -34,11 +34,16 @@ export default class MenuItem extends Component {
     action: PropTypes.func,
     disabled: PropTypes.bool,
     checked: PropTypes.bool,
+    indent: PropTypes.bool,
     shortcut: PropTypes.string,
     classes: PropTypes.string,
     close: PropTypes.func.isRequired,
     menuItems: PropTypes.array,
     openLeft: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    indent: false,
   };
 
   constructor() {
@@ -74,7 +79,7 @@ export default class MenuItem extends Component {
 
   render() {
     // indent if check able regardless of checked state
-    const indent = this.props.checked === true || this.props.checked === false;
+    const indent = this.props.indent || this.props.checked === true || this.props.checked === false;
     let check = null;
     if (indent) {
       check = <div className={this.props.checked ? 'menu-item-checked' : 'menu-item-unchecked'} />;

--- a/src/components/Menu/SubMenu.js
+++ b/src/components/Menu/SubMenu.js
@@ -46,6 +46,7 @@ export default function SubMenu(props) {
               menuItems={item.menuItems}
               close={props.close}
               openLeft={props.openLeft}
+              indent={item.indent}
             />) :
             (<MenuSeparator key={index} />)
         );

--- a/src/graphics/views/constructviewer.js
+++ b/src/graphics/views/constructviewer.js
@@ -417,7 +417,11 @@ export class ConstructViewer extends Component {
 
     const extensionsWithBlockMenus = extensionsByRegion('menu:block')
     .filter(manifest => manifest.render['menu:block'])
-    .map(manifest => manifest.render['menu:block'](singleBlock, firstBlock));
+    .map(manifest =>
+      manifest.render['menu:block'](singleBlock, firstBlock)
+      // Indent all extension menuItems
+      .map(menuItem => Object.assign({}, menuItem, { indent: true })),
+    );
 
     const extensionMenuItems = extensionsWithBlockMenus.length > 0 ? [
       {},

--- a/src/graphics/views/constructviewer.js
+++ b/src/graphics/views/constructviewer.js
@@ -454,8 +454,8 @@ export class ConstructViewer extends Component {
           this.selectEmptyBlocks();
         },
       },
-      ...GlobalNav.getSingleton().getEditMenuItems(),
       ...extensionMenuItems,
+      ...GlobalNav.getSingleton().getEditMenuItems(),
     ];
   };
 

--- a/src/graphics/views/constructviewer.js
+++ b/src/graphics/views/constructviewer.js
@@ -421,7 +421,7 @@ export class ConstructViewer extends Component {
 
     const extensionMenuItems = extensionsWithBlockMenus.length > 0 ? [
       {},
-      { text: 'Extensions', disabled: true },
+      { text: 'Plugins', disabled: true },
       ...flatten(extensionsWithBlockMenus),
     ] : [];
 


### PR DESCRIPTION
Issue: https://github.com/Autodesk/genetic-constructor/issues/1758

This PR makes a few tweaks to the plugins context menu to make it match the spec in [zeplin](https://app.zeplin.io/project.html#pid=581d0bc0b7502238616341cb&sid=58a4ea278d3c3a5d387d7986).

![screen shot 2017-04-13 at 2 22 35 pm](https://cloud.githubusercontent.com/assets/389558/25024883/ae24660a-2054-11e7-8427-8d00d3a2b255.png)
