### PR TITLE
BUILD FIX: fix reference to DB image in ./storage-ext

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -20,7 +20,7 @@ webapp:
 
 db:
   extends:
-    file: ./storage-ext/docker-compose-common.yml
+    file: ./storage-ext/docker-compose-local.yml
     service: db
   build: ./storage-ext/postgres/
 
@@ -28,7 +28,5 @@ redis:
   restart: always
   image: redis:3.2.0-alpine
   command: redis-server /usr/local/etc/redis/redis.conf
-  ports:
-    - "6379:6379"
   volumes:
     - ./redis.conf:/usr/local/etc/redis/redis.conf


### PR DESCRIPTION
#### Overview

Somehow forgot to commit a change to the main GC `docker-compose` configuration upon cleaning up the `docker-compose` configuration for the GC storage app. This broke the Jenkins build and is blocking deploys of the `master` branch to the `dev` environment.

This change updates the name of the configuration file used to run the PostgreSQL DB during unit testing in Jenkins.

#### Type of change (bug fix, feature, docs, UI, etc.)

Bug Fix

#### Breaking Changes

Fixes already broken Jenkins build.

#### Issue

#1782